### PR TITLE
Image Resize は行わない ReadWithWrite を追加

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/morikuni/failure v0.13.0
 	github.com/sinmetalcraft/goma v0.0.1
 	github.com/vvakame/sdlog v0.0.0-20200409072131-7c0d359efddc
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )

--- a/image_handler.go
+++ b/image_handler.go
@@ -2,7 +2,6 @@ package silverdile
 
 import (
 	"fmt"
-	"github.com/sinmetalcraft/silverdile/v2"
 	"net/http"
 	"strings"
 
@@ -23,7 +22,7 @@ func ImageHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	o, err := silverdile.BuildImageOption(strings.Join(l[1:], "/"))
+	o, err := BuildImageOption(strings.Join(l[1:], "/"))
 	if failure.Is(err, InvalidArgument) {
 		fmt.Printf("404: %+v\n", err)
 		w.WriteHeader(http.StatusNotFound)

--- a/url.go
+++ b/url.go
@@ -1,10 +1,11 @@
 package silverdile
 
 import (
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/morikuni/failure"
 )
 
 const MinResizeSize = 0
@@ -30,7 +31,7 @@ func BuildImageOption(path string) (*ImageOption, error) {
 
 	blocks := strings.Split(path, "/")
 	if len(blocks) < 3 {
-		return nil, NewErrInvalidArgument("Fewer expected blocks separated by `/`", map[string]interface{}{}, nil)
+		return nil, failure.New(InvalidArgument, failure.Messagef("Fewer expected blocks separated by `/`"))
 	}
 	ret.Bucket = blocks[1]
 	ret.Object = blocks[2]
@@ -49,11 +50,11 @@ func BuildImageOption(path string) (*ImageOption, error) {
 			return nil, err
 		}
 		if size < MinResizeSize || size > MaxResizeSize {
-			return nil, NewErrInvalidArgument(fmt.Sprintf("invalid resize arugment. size range is %d ~ %d, but got %d", MinResizeSize, MaxResizeSize, size), map[string]interface{}{}, nil)
+			return nil, failure.New(InvalidArgument, failure.Messagef("invalid resize arugment. size range is %d ~ %d, but got %d", MinResizeSize, MaxResizeSize, size))
 		}
 		ret.Size = size
 		return &ret, nil
 	}
 
-	return nil, NewErrInvalidArgument("invalid path", map[string]interface{}{"path": path}, nil)
+	return nil, failure.New(InvalidArgument)
 }

--- a/url_test.go
+++ b/url_test.go
@@ -1,11 +1,12 @@
-package silverdile
+package silverdile_test
 
 import (
-	"github.com/sinmetalcraft/silverdile/v2"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/morikuni/failure"
+
+	"github.com/sinmetalcraft/silverdile"
 )
 
 func TestBuildImageOption(t *testing.T) {
@@ -37,7 +38,7 @@ func TestBuildImageOptionError(t *testing.T) {
 		url  string
 		want failure.StringCode
 	}{
-		{"invalid argument", "/", InvalidArgument},
+		{"invalid argument", "/", silverdile.InvalidArgument},
 	}
 
 	for _, tt := range cases {

--- a/v2/errors.go
+++ b/v2/errors.go
@@ -1,29 +1,123 @@
 package silverdile
 
 import (
-	"github.com/morikuni/failure"
+	"fmt"
+
+	"golang.org/x/xerrors"
 )
 
-var InvalidArgument failure.StringCode = "InvalidArgument"
-var NotFound failure.StringCode = "NotFound"
-var InternalError failure.StringCode = "InternalError"
-
-func IsErrInvalidArgument(err error) bool {
-	return isError(err, InvalidArgument)
+// ErrNotFound is 見つからなかった時に返す
+var ErrNotFound = &Error{
+	Code:    "NotFound",
+	Message: "not found",
+	KV:      map[string]interface{}{},
 }
 
-func IsErrNotFound(err error) bool {
-	return isError(err, NotFound)
+// ErrInvalidArgument is 引数に問題がある時に返す
+var ErrInvalidArgument = &Error{
+	Code:    "InvalidArgument",
+	Message: "invalid argument",
+	KV:      map[string]interface{}{},
 }
 
-func IsErrInternalError(err error) bool {
-	return isError(err, InternalError)
+// ErrCloudStorage is Cloud Storage への API Request でエラーが発生した時に返す
+var ErrCloudStorage = &Error{
+	Code:    "CloudStorage",
+	Message: "failed cloud storage access",
+	KV:      map[string]interface{}{},
 }
 
-func isError(err error, code failure.StringCode) bool {
-	v, ok := failure.CodeOf(err)
-	if !ok {
+// ErrNeedConvert is Cloud Storage に キャッシュが見つからず、変換を行う必要がある時に返す
+var ErrNeedConvert = &Error{
+	Code:    "NeedConvert",
+	Message: "need to convert the object",
+	KV:      map[string]interface{}{},
+}
+
+// ErrInternalError is 何らかのエラーが発生した時に返す
+var ErrInternalError = &Error{
+	Code:    "InternalError",
+	Message: "internal error",
+	KV:      map[string]interface{}{},
+}
+
+// Error is Error情報を保持する struct
+type Error struct {
+	Code    string
+	Message string
+	KV      map[string]interface{}
+	err     error
+}
+
+// Error is error interface func
+func (e *Error) Error() string {
+	if e.KV == nil || len(e.KV) < 1 {
+		return fmt.Sprintf("%s: %s", e.Code, e.Message)
+	}
+	return fmt.Sprintf("%s: %s: attribute:%+v", e.Code, e.Message, e.KV)
+}
+
+// Is is err equal check
+func (e *Error) Is(target error) bool {
+	var appErr *Error
+	if !xerrors.As(target, &appErr) {
 		return false
 	}
-	return v == code
+	return e.Code == appErr.Code
+}
+
+// Unwrap is return unwrap error
+func (e *Error) Unwrap() error {
+	return e.err
+}
+
+// NewErrNotFound is return ErrNotFound
+func NewErrNotFound(key string, err error) error {
+	return &Error{
+		Code:    ErrNotFound.Code,
+		Message: ErrNotFound.Message,
+		KV: map[string]interface{}{
+			"Target": key,
+		},
+		err: err,
+	}
+}
+
+// NewErrInvalidArgument is return InvalidArgument
+func NewErrInvalidArgument(message string, kv map[string]interface{}, err error) error {
+	return &Error{
+		Code:    ErrInvalidArgument.Code,
+		Message: message,
+		KV:      kv,
+		err:     err,
+	}
+}
+
+// NewErrCloudStorage is return ErrCloudStorage
+func NewErrCloudStorage(message string, kv map[string]interface{}, err error) error {
+	return &Error{
+		Code:    ErrCloudStorage.Code,
+		Message: message,
+		KV:      kv,
+		err:     err,
+	}
+}
+
+// NewErrNeedConvert is return ErrNeedConvert
+func NewErrNeedConvert(message string, kv map[string]interface{}) error {
+	return &Error{
+		Code:    ErrNeedConvert.Code,
+		Message: message,
+		KV:      kv,
+	}
+}
+
+// NewErrInternalError is return ErrInternalError
+func NewErrInternalError(message string, kv map[string]interface{}, err error) error {
+	return &Error{
+		Code:    ErrInternalError.Code,
+		Message: message,
+		KV:      kv,
+		err:     err,
+	}
 }

--- a/v2/image_handler.go
+++ b/v2/image_handler.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/vvakame/sdlog/aelog"
+	"golang.org/x/xerrors"
 )
 
 type ImageHandlers struct {
@@ -36,7 +37,7 @@ func (h *ImageHandlers) ResizeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	o, err := BuildImageOption(strings.Join(l[1:], "/"))
-	if IsErrInvalidArgument(err) {
+	if xerrors.Is(err, ErrInvalidArgument) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, err := w.Write([]byte("invalid argument"))
 		if err != nil {
@@ -51,7 +52,7 @@ func (h *ImageHandlers) ResizeHandler(w http.ResponseWriter, r *http.Request) {
 	o.CacheControlMaxAge = 3600
 
 	err = h.imageService.ReadAndWrite(ctx, w, o)
-	if IsErrNotFound(err) {
+	if xerrors.Is(err, ErrNotFound) {
 		aelog.Infof(ctx, "404: bucket=%v,object=%v,err=%+v", o.Bucket, o.Object, err)
 		w.WriteHeader(http.StatusNotFound)
 		return

--- a/v2/image_handler_test.go
+++ b/v2/image_handler_test.go
@@ -14,11 +14,14 @@ import (
 	"github.com/sinmetalcraft/silverdile/v2"
 )
 
+const bucket = "sinmetal-ci-silverdile"
+const object = "jun0.jpg"
+
 func TestImageHandlerV2_NoResize(t *testing.T) {
 	ih := newTestImageHandlers(t)
 
 	// 適当なサイズで2回やってみる
-	r := httptest.NewRequest("GET", "https://example.com/v2/image/resize/sinmetal-ci-silverdile/jun0.jpg", nil)
+	r := httptest.NewRequest("GET", fmt.Sprintf("https://example.com/v2/image/resize/%s/%s", bucket, object), nil)
 	w := httptest.NewRecorder()
 
 	ih.ResizeHandler(w, r)
@@ -38,7 +41,7 @@ func TestImageHandlerV2_Resize(t *testing.T) {
 	size := rand.Intn(600)
 	for i := 0; i < 2; i++ {
 
-		r := httptest.NewRequest("GET", fmt.Sprintf("https://example.com/v2/image/resize/sinmetal-ci-silverdile/jun0.jpg/=s%d", size), nil)
+		r := httptest.NewRequest("GET", fmt.Sprintf("https://example.com/v2/image/resize/%s/%s/=s%d", bucket, object, size), nil)
 		w := httptest.NewRecorder()
 
 		ih.ResizeHandler(w, r)

--- a/v2/image_service_test.go
+++ b/v2/image_service_test.go
@@ -2,16 +2,99 @@ package silverdile_test
 
 import (
 	"context"
+	"net/http/httptest"
 	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/sinmetalcraft/goma"
+	"golang.org/x/xerrors"
 
 	"github.com/sinmetalcraft/silverdile/v2"
 )
 
-func TestWithAlterBucket(t *testing.T) {
+func TestImageService_ExistObject(t *testing.T) {
+	ctx := context.Background()
+
+	is := newImageService(t)
+
+	cases := []struct {
+		name   string
+		object string
+		want   error
+	}{
+		{"exist", object, nil},
+		{"not found", "momomomomo", silverdile.ErrNotFound},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := is.ExistObject(ctx, &silverdile.ImageOption{
+				Bucket: bucket,
+				Object: tt.object,
+			})
+			if !xerrors.Is(got, tt.want) {
+				t.Errorf("want %v but got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestImageService_ReadAndWriteWithoutResize(t *testing.T) {
+	ctx := context.Background()
+
+	is := newImageService(t)
+
+	const existSize = 100
+	{ // 先に existSize の Object は作っておく
+		w := httptest.NewRecorder()
+		err := is.ReadAndWrite(ctx, w, &silverdile.ImageOption{
+			Bucket: bucket,
+			Object: object,
+			Size:   existSize,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := []struct {
+		name   string
+		object string
+		size   int
+		want   error
+	}{
+		{"exist", object, existSize, nil},
+		{"not found", object, 666, silverdile.ErrNeedConvert},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			err := is.ReadAndWriteWithoutResize(ctx, w, &silverdile.ImageOption{
+				Bucket: bucket,
+				Object: object,
+				Size:   tt.size,
+			})
+			if !xerrors.Is(err, tt.want) {
+				t.Errorf("wang %v but got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestImageService_WithAlterBucket(t *testing.T) {
 	ctx := context.Background()
 
 	const bucket = "Hello"
-	is, err := silverdile.NewImageService(ctx, nil, nil, silverdile.WithAlterBucket(bucket))
+	gcs, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gomas := goma.NewStorageService(ctx, gcs)
+
+	is, err := silverdile.NewImageService(ctx, gcs, gomas, silverdile.WithAlterBucket(bucket))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,4 +102,21 @@ func TestWithAlterBucket(t *testing.T) {
 	if e, g := bucket, silverdile.GetImageServiceAlterBucket(t, is); e != g {
 		t.Errorf("want %v but got %v", e, g)
 	}
+}
+
+func newImageService(t *testing.T) *silverdile.ImageService {
+	ctx := context.Background()
+
+	gcs, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gomas := goma.NewStorageService(ctx, gcs)
+	is, err := silverdile.NewImageService(ctx, gcs, gomas)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return is
 }

--- a/v2/url_test.go
+++ b/v2/url_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/morikuni/failure"
+	"golang.org/x/xerrors"
 
 	"github.com/sinmetalcraft/silverdile/v2"
 )
@@ -36,24 +36,17 @@ func TestBuildImageOptionError(t *testing.T) {
 	cases := []struct {
 		name string
 		url  string
-		want failure.StringCode
+		want error
 	}{
-		{"invalid argument", "/", silverdile.InvalidArgument},
+		{"invalid argument", "/", silverdile.ErrInvalidArgument},
 	}
 
 	for _, tt := range cases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := silverdile.BuildImageOption(tt.url)
-			if err == nil {
-				t.Errorf("not error")
-			}
-			code, ok := failure.CodeOf(err)
-			if !ok {
-				t.Errorf("want %+v but got nothing code. err=%+v", tt.want, err)
-			}
-			if e, g := tt.want, code; e != g {
-				t.Errorf("want %+v but got %+v", e, g)
+			if !xerrors.Is(err, tt.want) {
+				t.Errorf("want %+v but got %+v", err, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
File Transfer はメモリが結構必要になるので、Cache が Hit した時だけ、io.Copy を実行する関数を追加した。
Resize は別 Instance に行ってもらうような構成の時に利用する。